### PR TITLE
Add new dashboard template layout and assets

### DIFF
--- a/admin/views/overview.php
+++ b/admin/views/overview.php
@@ -1,0 +1,100 @@
+<?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    exit('No direct script access.');
+}
+
+$title = 'WP Secure Admin – Dashboard';
+$logo = '/static/img/logo.png';
+$sidebar = [
+    'Main' => [
+        ['label' => 'Dashboard', 'href' => '#', 'active' => true],
+        ['label' => 'Orders', 'href' => '#'],
+        ['label' => 'Tickets', 'href' => '#'],
+        ['label' => 'Clients', 'href' => '#'],
+    ],
+    'Setup' => [
+        ['label' => 'Services', 'href' => '#'],
+        ['label' => 'Forms', 'href' => '#'],
+        ['label' => 'Settings', 'href' => '#'],
+    ],
+];
+$notifications = $notifications ?? [
+    ['title' => 'Security scan completed', 'message' => 'No threats detected on 12 sites.'],
+    ['title' => 'New ticket: Malware cleanup', 'message' => 'Assigned to Riley – due tomorrow.'],
+];
+
+ob_start();
+?>
+<section id="dashboard-overview" class="card chart-card">
+    <div class="toolbar" style="justify-content:space-between">
+        <div class="range">
+            <input id="dateRangeText" readonly>
+            <button class="iconbtn" id="todayBtn" title="Today" type="button">📅</button>
+        </div>
+        <div style="display:flex;gap:10px">
+            <div class="menu" id="reportsMenu">
+                <button class="btn ghost" id="reportsBtn" type="button">Reports ▾</button>
+                <div class="dropdown">
+                    <a href="#" data-report="sales">Sales report</a>
+                    <a href="#" data-report="clients">New clients</a>
+                </div>
+            </div>
+            <div class="menu" id="exportMenu">
+                <button class="btn ghost" id="exportBtn" type="button">Export ▾</button>
+                <div class="dropdown">
+                    <a href="#" data-export="csv">CSV</a>
+                    <a href="#" data-export="json">JSON</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <canvas id="ordersChart" height="120" style="margin-top:14px"></canvas>
+
+    <div class="kpis">
+        <div class="kpi">
+            <div class="label">Revenue</div>
+            <div class="value" id="kpiRevenue">—</div>
+        </div>
+        <div class="kpi">
+            <div class="label">New Clients</div>
+            <div class="value" id="kpiClients">—</div>
+        </div>
+        <div class="kpi">
+            <div class="label">Average Order</div>
+            <div class="value" id="kpiAOV">—</div>
+        </div>
+    </div>
+</section>
+
+<section class="card">
+    <div class="h1">Recent Orders</div>
+    <table class="table small">
+        <thead>
+            <tr>
+                <th>Client</th>
+                <th>Service</th>
+                <th>Status</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Ruth Watson</td>
+                <td>Site Care</td>
+                <td><span class="badge ok">Active</span></td>
+                <td>Oct 6</td>
+            </tr>
+            <tr>
+                <td>John Doe</td>
+                <td>Malware Cleanup</td>
+                <td><span class="badge warn">Pending</span></td>
+                <td>Oct 5</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<?php
+$content = ob_get_clean();
+
+require __DIR__ . '/../../templates/partials/dashboard_layout.php';

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,85 @@
+:root{
+  --bg:#0b0c10; --panel:#111827; --panel-2:#0f1625; --border:#1f2937;
+  --muted:#9aa7b8; --text:#e5e7eb;
+  --brand-start:#ff4d73;
+  --brand-end:#7b3ff2;
+  --danger:#ef4444; --warn:#f59e0b; --ok:#10b981;
+  --font:Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
+
+*{box-sizing:border-box}
+html,body{height:100%;margin:0}
+body{background:var(--bg);color:var(--text);font:14px/1.5 var(--font)}
+
+a{color:inherit}
+
+.layout{display:grid;grid-template-columns:280px 1fr;min-height:100vh}
+.sidebar{background:linear-gradient(180deg,#0e1524 0%,#0b0f1a 100%);border-right:1px solid var(--border);position:sticky;top:0;height:100vh;overflow:auto}
+.sidebar .brand{display:flex;align-items:center;gap:.6rem;padding:16px 18px;border-bottom:1px solid var(--border);font-weight:600}
+.sidebar .brand img{height:22px}
+.nav{padding:10px 8px}
+.nav .group{margin:16px 8px 8px;color:var(--muted);font-size:.75rem;text-transform:uppercase;letter-spacing:.08em}
+.nav a{display:flex;align-items:center;gap:.6rem;padding:10px 12px;border-radius:10px;text-decoration:none;color:var(--text);border:1px solid transparent}
+.nav a:hover{background:#141c2e;border-color:#1a2540}
+.nav a.active{background:linear-gradient(90deg,var(--brand-start),var(--brand-end));border:none;color:#fff}
+
+.shell{display:flex;flex-direction:column;min-height:100vh;background:var(--panel-2)}
+
+.topbar{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid var(--border);background:var(--panel);position:sticky;top:0;z-index:90}
+.search{flex:1;display:flex;align-items:center;background:#0c1424;border:1px solid var(--border);border-radius:10px}
+.search input{flex:1;background:transparent;border:0;color:var(--text);padding:10px 12px;font:inherit;outline:none}
+.iconbtn{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:10px;background:#0f1625;border:1px solid var(--border);cursor:pointer;color:var(--text);font-size:1.2rem}
+.avatar{width:32px;height:32px;border-radius:50%;background:#223;display:inline-block}
+
+main{padding:20px;flex:1}
+.h1{font-size:1.4rem;font-weight:600;margin:2px 0 16px}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:16px;margin-bottom:16px}
+.subtle{color:var(--muted)}
+.btn{display:inline-flex;align-items:center;gap:.5rem;border:1px solid var(--border);background:#0f1625;color:var(--text);padding:10px 14px;border-radius:10px;text-decoration:none;cursor:pointer}
+.btn.primary{background:linear-gradient(90deg,var(--brand-start),var(--brand-end));border:none;color:#fff}
+.btn.primary:hover{filter:brightness(.95)}
+.btn.ghost{background:transparent}
+
+.table{width:100%;border-collapse:collapse}
+.table th,.table td{border-bottom:1px solid var(--border);padding:10px 8px;text-align:left}
+.table th{color:var(--muted);font-weight:600;font-size:.85rem}
+.table tr:hover td{background:#0d1527}
+
+.toolbar{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.toolbar .range{display:flex;align-items:center;gap:8px;background:#0c1424;border:1px solid var(--border);border-radius:10px;padding:10px 12px;min-width:260px}
+.toolbar .range input{background:transparent;border:0;color:var(--text);outline:none}
+.toolbar .menu{position:relative}
+.toolbar .menu>button{min-width:120px}
+.menu .dropdown{position:absolute;top:110%;right:0;background:var(--panel);border:1px solid var(--border);border-radius:10px;min-width:160px;display:none;overflow:hidden}
+.menu .dropdown a{display:block;padding:10px 12px;color:var(--text);text-decoration:none}
+.menu .dropdown a:hover{background:#141c2e}
+.menu.open .dropdown{display:block}
+
+.chart-card{padding:16px 16px 8px}
+.kpis{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:12px}
+.kpi{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:20px;text-align:center}
+.kpi .label{color:var(--muted);margin-bottom:8px}
+.kpi .value{font-size:1.2rem;font-weight:700}
+
+.badge{display:inline-block;padding:.25rem .5rem;border-radius:999px;font-size:.75rem}
+.badge.ok{background:#0a2e23;color:#69e1b9}
+.badge.warn{background:#2b2006;color:#f9cf72}
+.badge.muted{background:#202735;color:#a8b3c7}
+
+.notifications ul{margin:0;padding:0;list-style:none;display:grid;gap:12px}
+.notifications li{padding:12px;border:1px solid var(--border);border-radius:10px;background:#0f1625}
+
+.mobile-menu{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-start;z-index:100}
+.mobile-menu.open{display:flex}
+.mobile-sidebar{background:var(--panel);width:260px;height:100vh;padding:20px;border-right:1px solid var(--border);transform:translateX(-100%);transition:transform .3s ease}
+.mobile-menu.open .mobile-sidebar{transform:translateX(0)}
+.mobile-sidebar .brand{display:flex;align-items:center;gap:.6rem;margin-bottom:20px;font-weight:600}
+.mobile-sidebar a{display:block;color:var(--text);padding:10px 0;text-decoration:none;border-bottom:1px solid var(--border)}
+.mobile-sidebar a:hover{color:#fff;background:linear-gradient(90deg,var(--brand-start),var(--brand-end));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+
+@media (max-width:900px){
+  .layout{grid-template-columns:1fr}
+  .sidebar{display:none}
+}
+
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,174 @@
+(function(){
+  const qs = (sel, ctx=document) => ctx.querySelector(sel);
+  const qsa = (sel, ctx=document) => Array.from(ctx.querySelectorAll(sel));
+
+  /* ===== Mobile menu ===== */
+  const menuBtn = qs('#menuBtn');
+  const mobileMenu = qs('#mobileMenu');
+  if (menuBtn && mobileMenu) {
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('open');
+      if (mobileMenu.classList.contains('open')) {
+        mobileMenu.removeAttribute('hidden');
+      } else {
+        mobileMenu.setAttribute('hidden', '');
+      }
+    });
+    mobileMenu.addEventListener('click', (evt) => {
+      if (evt.target === mobileMenu) {
+        mobileMenu.classList.remove('open');
+        mobileMenu.setAttribute('hidden', '');
+      }
+    });
+  }
+
+  /* ===== Dropdown menus ===== */
+  qsa('.menu').forEach((menu) => {
+    const trigger = menu.querySelector('button');
+    if (!trigger) return;
+    trigger.addEventListener('click', (evt) => {
+      evt.preventDefault();
+      menu.classList.toggle('open');
+    });
+  });
+  document.addEventListener('click', (evt) => {
+    qsa('.menu.open').forEach((menu) => {
+      if (!menu.contains(evt.target)) {
+        menu.classList.remove('open');
+      }
+    });
+  });
+
+  /* ===== Notification drawer support ===== */
+  const notificationToggle = qs('[data-notification-toggle]');
+  const notificationPanel = qs('[data-notification-panel]');
+  if (notificationToggle && notificationPanel) {
+    notificationToggle.addEventListener('click', () => {
+      notificationPanel.toggleAttribute('hidden');
+    });
+  }
+
+  /* ===== Date helpers ===== */
+  const rangeInput = qs('#dateRangeText');
+  const todayBtn = qs('#todayBtn');
+  function formatRange(from, to) {
+    const fmt = (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    return `${fmt(from)} to ${fmt(to)}`;
+  }
+  function lastNDays(n) {
+    const labels = [];
+    const now = new Date();
+    for (let i = n - 1; i >= 0; i -= 1) {
+      const d = new Date(now);
+      d.setDate(now.getDate() - i);
+      labels.push(d);
+    }
+    return labels;
+  }
+  if (rangeInput) {
+    const days = lastNDays(30);
+    rangeInput.value = formatRange(days[0], days[days.length - 1]);
+  }
+  if (todayBtn && rangeInput) {
+    todayBtn.addEventListener('click', () => {
+      const today = new Date();
+      rangeInput.value = formatRange(today, today);
+      document.dispatchEvent(new CustomEvent('dashboard:today'));
+    });
+  }
+
+  /* ===== Chart.js setup ===== */
+  function initialiseChart() {
+    const canvas = qs('#ordersChart');
+    if (!canvas || typeof Chart === 'undefined') {
+      return null;
+    }
+    const existing = Chart.getChart(canvas);
+    if (existing) existing.destroy();
+
+    return new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: [],
+        datasets: [{
+          label: 'Orders',
+          data: [],
+          backgroundColor: '#2f6bff',
+          borderRadius: 6,
+          borderSkipped: false,
+          barThickness: 18
+        }]
+      },
+      options: {
+        maintainAspectRatio: false,
+        animation: false,
+        transitions: { active: { animation: { duration: 0 } } },
+        scales: {
+          x: { grid: { display: false }, ticks: { color: '#aab3c2' } },
+          y: { grid: { color: 'rgba(255,255,255,0.06)' }, ticks: { color: '#aab3c2', callback: (v) => '$' + v } }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: (ctx) => `$${ctx.parsed.y}` } }
+        }
+      }
+    });
+  }
+
+  const chart = initialiseChart();
+  const KPI_IDS = {
+    revenue: 'kpiRevenue',
+    clients: 'kpiClients',
+    aov: 'kpiAOV'
+  };
+
+  const FIXED_DEMO = (() => {
+    const labels = [];
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 29);
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      labels.push(d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }));
+    }
+    const series = [
+      440, 420, 430, 280, 360, 350, 370, 470, 490, 430,
+      400, 420, 460, 310, 480, 430, 410, 460, 420, 450,
+      330, 470, 430, 450, 420, 310, 480, 500, 430, 440
+    ];
+    const revenue = series.reduce((acc, value) => acc + value, 0);
+    const averageOrder = revenue / series.length;
+    const newClients = 18;
+    return { labels, series, revenue, newClients, averageOrder };
+  })();
+
+  function formatCurrency(value) {
+    return value != null
+      ? value.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
+      : '—';
+  }
+
+  function updateKpi(id, value) {
+    const el = qs(`#${id}`);
+    if (!el) return;
+    el.textContent = value;
+  }
+
+  function setDashboardData(data) {
+    if (chart) {
+      chart.data.labels = data.labels;
+      chart.data.datasets[0].data = data.series;
+      chart.update();
+    }
+    updateKpi(KPI_IDS.revenue, formatCurrency(data.revenue));
+    updateKpi(KPI_IDS.clients, data.newClients ?? '—');
+    updateKpi(KPI_IDS.aov, data.averageOrder != null
+      ? data.averageOrder.toLocaleString(undefined, { style: 'currency', currency: 'USD' })
+      : '—');
+  }
+
+  window.dashboard = Object.assign(window.dashboard || {}, {
+    setDashboardData
+  });
+
+  setDashboardData(FIXED_DEMO);
+})();

--- a/templates/client/pages/dashboard.php
+++ b/templates/client/pages/dashboard.php
@@ -1,0 +1,66 @@
+<?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    exit('No direct script access.');
+}
+
+$title = $title ?? 'Client Dashboard';
+$logo = $logo ?? '/static/img/logo.png';
+$sidebar = $sidebar ?? [
+    'Account' => [
+        ['label' => 'Dashboard', 'href' => '#', 'active' => true],
+        ['label' => 'Services', 'href' => '#'],
+        ['label' => 'Invoices', 'href' => '#'],
+        ['label' => 'Support', 'href' => '#'],
+    ],
+];
+$notifications = $notifications ?? [];
+
+ob_start();
+?>
+<section class="card">
+    <div class="h1">Welcome back</div>
+    <p class="subtle">Here’s what’s happening with your services.</p>
+    <div class="kpis">
+        <div class="kpi">
+            <div class="label">Active Services</div>
+            <div class="value">3</div>
+        </div>
+        <div class="kpi">
+            <div class="label">Open Tickets</div>
+            <div class="value">1</div>
+        </div>
+        <div class="kpi">
+            <div class="label">Last Payment</div>
+            <div class="value">Sep 28</div>
+        </div>
+    </div>
+</section>
+
+<section class="card">
+    <div class="h1">Recent Activity</div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Event</th>
+                <th>Status</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Security scan – Main site</td>
+                <td><span class="badge ok">Clean</span></td>
+                <td>Oct 6</td>
+            </tr>
+            <tr>
+                <td>Support ticket reply</td>
+                <td><span class="badge muted">Awaiting customer</span></td>
+                <td>Oct 4</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<?php
+$content = ob_get_clean();
+
+require __DIR__ . '/../../partials/dashboard_layout.php';

--- a/templates/partials/dashboard_layout.php
+++ b/templates/partials/dashboard_layout.php
@@ -1,0 +1,105 @@
+<?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    exit('No direct script access.');
+}
+
+$sidebar = $sidebar ?? [];
+$notifications = $notifications ?? [];
+$title = $title ?? 'Dashboard';
+$logo = $logo ?? null;
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
+    <link rel="stylesheet" href="/static/css/app.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+    <script defer src="/static/js/app.js"></script>
+</head>
+<body>
+<div class="layout">
+    <aside class="sidebar" aria-label="Primary">
+        <div class="brand">
+            <?php if ($logo): ?>
+                <img src="<?= htmlspecialchars($logo, ENT_QUOTES, 'UTF-8'); ?>" alt="" loading="lazy">
+            <?php endif; ?>
+            <span><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></span>
+        </div>
+        <nav class="nav">
+            <?php foreach ($sidebar as $group => $items): ?>
+                <?php if ($group !== '' && !is_numeric($group)): ?>
+                    <div class="group"><?= htmlspecialchars($group, ENT_QUOTES, 'UTF-8'); ?></div>
+                <?php endif; ?>
+                <?php foreach ($items as $item): ?>
+                    <?php
+                    $label = $item['label'] ?? '';
+                    $href = $item['href'] ?? '#';
+                    $active = !empty($item['active']);
+                    ?>
+                    <a href="<?= htmlspecialchars($href, ENT_QUOTES, 'UTF-8'); ?>" class="<?= $active ? 'active' : ''; ?>">
+                        <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                <?php endforeach; ?>
+            <?php endforeach; ?>
+        </nav>
+    </aside>
+
+    <div class="shell">
+        <header class="topbar">
+            <button class="iconbtn" id="menuBtn" type="button" aria-label="Toggle menu">☰</button>
+            <form class="search" method="get" action="/search">
+                <input type="search" name="q" placeholder="Search…" value="<?= htmlspecialchars($_GET['q'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+            </form>
+            <button class="iconbtn" type="button" data-help>?</button>
+            <button class="iconbtn" type="button" data-notification-toggle>🔔
+                <?php if (!empty($notifications)): ?>
+                    <span class="sr-only">You have <?= count($notifications); ?> notifications</span>
+                <?php endif; ?>
+            </button>
+            <span class="avatar" aria-hidden="true"></span>
+        </header>
+
+        <main>
+            <?php if (!empty($notifications)): ?>
+                <section class="card notifications" data-notification-panel hidden>
+                    <div class="h1">Notifications</div>
+                    <ul>
+                        <?php foreach ($notifications as $note): ?>
+                            <li>
+                                <strong><?= htmlspecialchars($note['title'] ?? '', ENT_QUOTES, 'UTF-8'); ?></strong>
+                                <p class="subtle"><?= htmlspecialchars($note['message'] ?? '', ENT_QUOTES, 'UTF-8'); ?></p>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </section>
+            <?php endif; ?>
+
+            <?= $content ?? ''; ?>
+        </main>
+    </div>
+</div>
+
+<div class="mobile-menu" id="mobileMenu" hidden>
+    <div class="mobile-sidebar">
+        <div class="brand">
+            <?php if ($logo): ?>
+                <img src="<?= htmlspecialchars($logo, ENT_QUOTES, 'UTF-8'); ?>" alt="" loading="lazy">
+            <?php endif; ?>
+            <span><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></span>
+        </div>
+        <?php foreach ($sidebar as $group => $items): ?>
+            <?php if ($group !== '' && !is_numeric($group)): ?>
+                <div class="group"><?= htmlspecialchars($group, ENT_QUOTES, 'UTF-8'); ?></div>
+            <?php endif; ?>
+            <?php foreach ($items as $item): ?>
+                <a href="<?= htmlspecialchars($item['href'] ?? '#', ENT_QUOTES, 'UTF-8'); ?>">
+                    <?= htmlspecialchars($item['label'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                </a>
+            <?php endforeach; ?>
+        <?php endforeach; ?>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable dashboard layout partial with sidebar, topbar, and notification support
- recreate admin and client dashboard views using the new section structure
- add the matching dark theme styles and JavaScript for menus, notifications, and chart data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e558aee94c8330857914664b9b95e0